### PR TITLE
Fix error message typo

### DIFF
--- a/src/StartNewExperiment.jsx
+++ b/src/StartNewExperiment.jsx
@@ -204,7 +204,7 @@ function ExperimentSummaryForm(props) {
         }
         else {
           setFormError(true);
-          setHelperText("Sever error. See UI logs.")
+          setHelperText("Server error. See UI logs.")
         }
         setLoading(false)
       }


### PR DESCRIPTION
## Summary
- fix typo in StartNewExperiment error message

## Testing
- `npm test` *(fails: `react-scripts: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684e05a6f9088322a7f77595c4b5f790