### PR TITLE
Fix recursion params in checkTaskCallback

### DIFF
--- a/src/utilities.js
+++ b/src/utilities.js
@@ -172,12 +172,12 @@ export async function checkTaskCallback(callbackURL, {maxRetries = 100, delayMs 
     }
     // If not 200, wait, decrement retry count, try again
     await new Promise((resolve) => setTimeout(resolve, delayMs));
-    return checkTaskCallback(callbackURL, maxRetries - 1, delayMs);
+    return checkTaskCallback(callbackURL, {maxRetries: maxRetries - 1, delayMs});
   } catch (err) {
     console.error('Error fetching callback:', err);
     // Wait, decrement retry count, try again
     await new Promise((resolve) => setTimeout(resolve, delayMs));
-    return checkTaskCallback(callbackURL, maxRetries - 1, delayMs);
+    return checkTaskCallback(callbackURL, {maxRetries: maxRetries - 1, delayMs});
   }
 }
 


### PR DESCRIPTION
## Summary
- adjust checkTaskCallback recursion to pass options object

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e0582a0648322ae4ab03171e85afa